### PR TITLE
Remove unused logout from profile page

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -11,24 +11,10 @@ import LinkedInIcon from "../assets/icons/LinkedInIcon";
 import GitHubIcon from "../assets/icons/GitHubIcon";
 import ProfileIconText from "../components/ProfileIconText";
 import BentoWhiteBox from "../components/ui/BentoWhiteBox";
-import { useNavigate } from "react-router-dom";
-import { AuthService, useCurrentUser } from "../services";
+import { useCurrentUser } from "../services";
 
 const Profile: React.FC<EditProfileProps> = ({}) => {
-  const navigate = useNavigate();
-  const { userData, loading, error, refetch } = useCurrentUser();
-  void refetch;
-
-  console.log("Datos del usuario:", userData);
-
-  const handleLogout = async () => {
-    try {
-      await AuthService.signOut();
-      navigate("/signin");
-    } catch (error) {
-      console.error("Error al cerrar sesión:", error);
-    }
-  };
+  const { userData, loading, error } = useCurrentUser();
 
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const handleSaveProfile = async (


### PR DESCRIPTION
## Summary
- clean up `Profile.tsx` by dropping debug statements and unused logout handler

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68438120dfd483239879d9f72eb4a0eb