### PR TITLE
Add SocialLinks component

### DIFF
--- a/src/components/profiles/SocialLinks.tsx
+++ b/src/components/profiles/SocialLinks.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import LinkedInIcon from "../../assets/icons/LinkedInIcon";
+import ArrowRightIcon from "../../assets/icons/ArrowRightIcon";
+import GitHubIcon from "../../assets/icons/GitHubIcon";
+
+interface SocialLinksProps {
+  linkedin?: string;
+  portfolio?: string;
+  github?: string;
+  website?: string;
+}
+
+const SocialLinks: React.FC<SocialLinksProps> = ({
+  linkedin,
+  portfolio,
+  github,
+  website,
+}) => {
+  return (
+    <div className="space-y-2">
+      {linkedin && (
+        <a
+          href={linkedin}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 text-blue-600 hover:text-blue-700 transition-colors"
+        >
+          <LinkedInIcon />
+          LinkedIn
+        </a>
+      )}
+
+      {portfolio && (
+        <a
+          href={portfolio}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 text-green-600 hover:text-green-700 transition-colors"
+        >
+          <ArrowRightIcon />
+          Portfolio
+        </a>
+      )}
+
+      {github && (
+        <a
+          href={github}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 text-gray-600 hover:text-gray-700 transition-colors"
+        >
+          <GitHubIcon />
+          GitHub
+        </a>
+      )}
+
+      {website && (
+        <a
+          href={website}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 text-purple-600 hover:text-purple-700 transition-colors"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+            />
+          </svg>
+          Website
+        </a>
+      )}
+    </div>
+  );
+};
+
+export default SocialLinks;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -2,13 +2,11 @@ import React, { useState } from "react";
 import EditProfileModal from "../components/profiles/EditProfileModal";
 import { ProfileService } from "../services/profile/ProfileService";
 import Button from "../components/buttons/Button";
-import ArrowRightIcon from "../assets/icons/ArrowRightIcon";
 import { EditProfileProps } from "../interfaces/editProfile.interface";
 import ShareProfileButton from "../components/ShareButton";
 import Title from "../components/ui/Title";
 import Paragraph from "../components/ui/Paragraph";
-import LinkedInIcon from "../assets/icons/LinkedInIcon";
-import GitHubIcon from "../assets/icons/GitHubIcon";
+import SocialLinks from "../components/profiles/SocialLinks";
 import ProfileIconText from "../components/ProfileIconText";
 import BentoWhiteBox from "../components/ui/BentoWhiteBox";
 import { useNavigate } from "react-router-dom";
@@ -138,69 +136,12 @@ const Profile: React.FC<EditProfileProps> = ({}) => {
                     >
                       Enlaces
                     </Title>
-                    <div className="space-y-2">
-                      {userData.linkedin && (
-                        <a
-                          href={userData.linkedin}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center gap-2 text-blue-600 hover:text-blue-700 transition-colors"
-                        >
-                          <LinkedInIcon />
-                          LinkedIn
-                        </a>
-                      )}
-
-                      {userData.portfolio && (
-                        <a
-                          href={userData.portfolio}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center gap-2 text-green-600 hover:text-green-700 transition-colors"
-                        >
-                          <ArrowRightIcon />
-                          Portfolio
-                        </a>
-                      )}
-
-                      {/* PENDIENTE */}
-                      {userData.github && (
-                        <a
-                          href={userData.github}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center gap-2 text-gray-600 hover:text-gray-700 transition-colors"
-                        >
-                          <GitHubIcon />
-                          GitHub
-                        </a>
-                      )}
-
-                      {/* PENDIENTE */}
-                      {userData.website && (
-                        <a
-                          href={userData.website}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center gap-2 text-purple-600 hover:text-purple-700 transition-colors"
-                        >
-                          <svg
-                            className="w-4 h-4"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                            />
-                          </svg>
-                          Website
-                        </a>
-                      )}
-                    </div>
+                    <SocialLinks
+                      linkedin={userData.linkedin}
+                      portfolio={userData.portfolio}
+                      github={userData.github}
+                      website={userData.website}
+                    />
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- add `SocialLinks` component to display LinkedIn, Portfolio, GitHub and website links
- use the new component in `Profile` page

## Testing
- `pnpm install`
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684381987f1c8323a652ea619bd60751