### PR TITLE
Refactor SignIn page

### DIFF
--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -4,20 +4,57 @@ import WelcomeSection from "../components/sections/WelcomeSection";
 import SignInForm from "../components/SignIn";
 import FeatureShowcase from "../components/sections/ShowcaseSection";
 
-const SignIn: React.FC = () => {
+const containerMotion = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  transition: { duration: 0.6 },
+};
+
+const cardMotion = {
+  initial: { y: 30, opacity: 0 },
+  animate: { y: 0, opacity: 1 },
+  transition: { duration: 0.7, delay: 0.1 },
+};
+
+const logosMotion = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+  transition: { delay: 0.8, duration: 0.5 },
+};
+
+const logos = [
+  {
+    src: "https://brandlogos.net/wp-content/uploads/2021/04/microsoft-logo-512x512.png",
+    alt: "Microsoft",
+  },
+  {
+    src: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/53/Google_%22G%22_Logo.svg/2048px-Google_%22G%22_Logo.svg.png",
+    alt: "Google",
+  },
+  {
+    src: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Slack_Technologies_Logo.svg/2560px-Slack_Technologies_Logo.svg.png",
+    alt: "Slack",
+  },
+  {
+    src: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Meta_Platforms_Inc._logo.svg/2560px-Meta_Platforms_Inc._logo.svg.png",
+    alt: "Meta",
+  },
+  {
+    src: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Apple_logo_black.svg/1667px-Apple_logo_black.svg.png",
+    alt: "Apple",
+  },
+];
+
+const SignInPage: React.FC = () => {
   return (
-    <motion.div 
+    <motion.div
       className="w-full min-h-[calc(100vh-80px)] py-8 lg:py-12 bg-gray-50"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.6 }}
+      {...containerMotion}
     >
       <div className="container mx-auto px-4">
-        <motion.div 
+        <motion.div
           className="flex w-full flex-col md:flex-row bg-white rounded-xl shadow-lg overflow-hidden max-w-5xl mx-auto"
-          initial={{ y: 30, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          transition={{ duration: 0.7, delay: 0.1 }}
+          {...cardMotion}
         >
           <div className="w-full md:w-2/5 p-6 md:p-8 lg:p-10 flex flex-col">
             <WelcomeSection />
@@ -29,19 +66,20 @@ const SignIn: React.FC = () => {
           </div>
         </motion.div>
         
-        <motion.div 
+        <motion.div
           className="mt-8 text-center max-w-5xl mx-auto"
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.8, duration: 0.5 }}
+          {...logosMotion}
         >
           <p className="text-sm text-gray-500 mb-4">Utilizado por miles de profesionales en empresas como:</p>
           <div className="flex flex-wrap justify-center items-center gap-8 opacity-60">
-            <img src="https://brandlogos.net/wp-content/uploads/2021/04/microsoft-logo-512x512.png" alt="Microsoft" className="h-6 object-contain grayscale" />
-            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/53/Google_%22G%22_Logo.svg/2048px-Google_%22G%22_Logo.svg.png" alt="Google" className="h-6 object-contain grayscale" />
-            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Slack_Technologies_Logo.svg/2560px-Slack_Technologies_Logo.svg.png" alt="Slack" className="h-6 object-contain grayscale" />
-            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Meta_Platforms_Inc._logo.svg/2560px-Meta_Platforms_Inc._logo.svg.png" alt="Meta" className="h-6 object-contain grayscale" />
-            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Apple_logo_black.svg/1667px-Apple_logo_black.svg.png" alt="Apple" className="h-6 object-contain grayscale" />
+            {logos.map((logo) => (
+              <img
+                key={logo.alt}
+                src={logo.src}
+                alt={logo.alt}
+                className="h-6 object-contain grayscale"
+              />
+            ))}
           </div>
         </motion.div>
       </div>
@@ -49,4 +87,4 @@ const SignIn: React.FC = () => {
   );
 };
 
-export default SignIn;
+export default SignInPage;

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -2,7 +2,7 @@ import { RouteObject } from "react-router-dom";
 import React from "react";
 import Home from "../pages/Home";
 import SignUp from "../pages/SignUp";
-import SignIn from "../pages/SignIn";
+import SignInPage from "../pages/SignIn";
 import AuthGuard from "../middlewares/AuthGuard";
 import NotFound from "../pages/404";
 import TemplateLoader from "../pages/templates/TemplateLoader";
@@ -20,7 +20,7 @@ export const routes: RouteObject[] = [
   },
   {
     path: "/signin",
-    element: React.createElement(SignIn),
+    element: React.createElement(SignInPage),
   },
   {
     path: "/terminos-y-condiciones",


### PR DESCRIPTION
## Summary
- refactor SignIn page component and rename to `SignInPage`
- centralize `framer-motion` props in variant objects
- render partner logos from an array
- update routes to use new component name

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844f37ef944832387b5945c6469b87b