### PR TITLE
Add FindApplicants public profiles page

### DIFF
--- a/src/components/applicants/ApplicantCard.tsx
+++ b/src/components/applicants/ApplicantCard.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Tag from '../Tag';
+import { PublicProfileInfo } from '../../services/interface/profile.interface';
+
+interface ApplicantCardProps {
+  profile: PublicProfileInfo;
+}
+
+const ApplicantCard: React.FC<ApplicantCardProps> = ({ profile }) => {
+  const skills = Array.isArray(profile.skills)
+    ? profile.skills
+        .map((s: any) =>
+          typeof s === 'string' ? s : s.skill?.name || s.name
+        )
+        .filter(Boolean)
+    : [];
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-6 flex flex-col">
+      <div className="flex items-center gap-4">
+        {profile.profile_photo && (
+          <img
+            src={profile.profile_photo}
+            alt={`${profile.first_name} ${profile.last_name}`}
+            className="w-16 h-16 rounded-full object-cover"
+          />
+        )}
+        <div>
+          <h3 className="text-lg font-semibold text-gray-800">
+            {profile.first_name} {profile.last_name}
+          </h3>
+          {profile.role && (
+            <p className="text-sm text-gray-500">{profile.role}</p>
+          )}
+          {profile.location && (
+            <p className="text-sm text-gray-500">{profile.location}</p>
+          )}
+        </div>
+      </div>
+      {skills.length > 0 && (
+        <div className="flex flex-wrap gap-2 mt-4">
+          {skills.slice(0, 3).map((skill, index) => (
+            <Tag key={index} label={skill} />
+          ))}
+          {skills.length > 3 && (
+            <span className="text-xs text-gray-500">
+              +{skills.length - 3} más
+            </span>
+          )}
+        </div>
+      )}
+      <Link
+        to={`/profile/${profile.id}`}
+        className="mt-4 text-sm text-blue-600 hover:underline font-medium"
+      >
+        Ver perfil
+      </Link>
+    </div>
+  );
+};
+
+export default ApplicantCard;

--- a/src/pages/FindApplicants.tsx
+++ b/src/pages/FindApplicants.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import SearchInput from '../components/SearchInput';
+import Title from '../components/ui/Title';
+import ApplicantCard from '../components/applicants/ApplicantCard';
+import LoadingSpinner from '../components/common/LoadingSpinner';
+import { ProfileService } from '../services';
+import { PublicProfileInfo } from '../services/interface/profile.interface';
+
+const FindApplicants: React.FC = () => {
+  const [profiles, setProfiles] = useState<PublicProfileInfo[]>([]);
+  const [filtered, setFiltered] = useState<PublicProfileInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchProfiles = async () => {
+      try {
+        const data = await ProfileService.getPublicProfiles();
+        setProfiles(data);
+        setFiltered(data);
+      } catch (error) {
+        console.error('Error al obtener perfiles públicos', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProfiles();
+  }, []);
+
+  const handleSearch = (query: string) => {
+    const q = query.toLowerCase();
+    const result = profiles.filter((p) => {
+      const fullName = `${p.first_name} ${p.last_name}`.toLowerCase();
+      const skills = Array.isArray(p.skills)
+        ? p.skills
+            .map((s: any) =>
+              typeof s === 'string' ? s : s.skill?.name || s.name
+            )
+            .join(' ')
+            .toLowerCase()
+        : '';
+      return (
+        fullName.includes(q) ||
+        (p.location && p.location.toLowerCase().includes(q)) ||
+        (p.role && p.role.toLowerCase().includes(q)) ||
+        skills.includes(q)
+      );
+    });
+    setFiltered(result);
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen bg-[#f6f7f9]">
+      <main className="flex-grow py-12">
+        <div className="container mx-auto px-4 md:px-6 lg:px-8 space-y-8">
+          <div className="max-w-xl space-y-4">
+            <Title size="md" weight="bold">
+              Buscar Talentos
+            </Title>
+            <SearchInput
+              placeholder="Buscar por nombre, habilidad o ubicación"
+              onSearch={handleSearch}
+            />
+          </div>
+          {loading ? (
+            <div className="flex justify-center mt-10">
+              <LoadingSpinner size={8} color="text-blue-600" />
+            </div>
+          ) : (
+            <>
+              {filtered.length > 0 ? (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {filtered.map((profile) => (
+                    <ApplicantCard key={profile.id} profile={profile} />
+                  ))}
+                </div>
+              ) : (
+                <p className="text-gray-600">No se encontraron perfiles.</p>
+              )}
+            </>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default FindApplicants;

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -3,6 +3,7 @@ import React from "react";
 import Home from "../pages/Home";
 import SignUp from "../pages/SignUp";
 import SignInPage from "../pages/SignIn";
+import FindApplicants from "../pages/FindApplicants";
 import AuthGuard from "../middlewares/AuthGuard";
 import NotFound from "../pages/404";
 import TemplateLoader from "../pages/templates/TemplateLoader";
@@ -25,6 +26,10 @@ export const routes: RouteObject[] = [
   {
     path: "/terminos-y-condiciones",
     element: React.createElement(TermsAndConditions),
+  },
+  {
+    path: "/talentos",
+    element: React.createElement(FindApplicants),
   },
   {
     path: "/profile",

--- a/src/services/config/api.config.ts
+++ b/src/services/config/api.config.ts
@@ -20,6 +20,7 @@ export const API_ENDPOINTS = {
     SAVE: "/users/save-profile/",
     GET: "/users/get-profile/",
     UPDATE: "/users/profile/",
-    PUBLIC: "/public/get-profile/"
+    PUBLIC: "/public/get-profile/",
+    PUBLIC_LIST: "/public/profiles"
   }
 } as const;

--- a/src/services/profile/ProfileService.ts
+++ b/src/services/profile/ProfileService.ts
@@ -30,4 +30,14 @@ export class ProfileService {
       return null;
     }
   }
+
+  static async getPublicProfiles(): Promise<PublicProfileInfo[] | []> {
+    try {
+      const response = await HttpClient.getPublic<ProfileServiceResponse>(API_ENDPOINTS.PROFILE.PUBLIC_LIST);
+      const data = (response as any).data;
+      return Array.isArray(data) ? data : [];
+    } catch (error) {
+      return [];
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add API endpoint for public profiles and service method
- create ApplicantCard component to display individual profiles
- implement FindApplicants page for recruiters to search talent
- register new route `/talentos` for the page

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js' and many lint errors)*
- `pnpm build` *(fails due to existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845078a5b8483238e872cb5189a582f